### PR TITLE
Allow cputemp and cpuhot to analyze all CPUs when the shell environme…

### DIFF
--- a/cpuhot
+++ b/cpuhot
@@ -53,7 +53,7 @@ if (( family != 6 )); then
 fi
 
 ### options
-ncpus=$(nproc)
+ncpus=$(nproc --all)
 
 if [[ "$USER" != "root" ]]; then
 	echo >&2 "ERROR: needs root access. Exiting."

--- a/cputemp
+++ b/cputemp
@@ -56,7 +56,7 @@ fi
 ### options
 opt_avg=0
 opt_util=0
-ncpus=$(nproc)
+ncpus=$(nproc --all)
 interval=1
 count=1
 


### PR DESCRIPTION
…nt has limited access to CPUs (e.g. via taskset).

This is accomplished using nproc's --all switch. I think this should always be used, since cpuhot even prints certain fields across all CPUs.